### PR TITLE
Updated einops typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ gradio
 dill
 accelerate
 timm
-einops=0.8.0
+einops==0.8.0


### PR DESCRIPTION
Fix typo in requirements.txt: corrected `einops=0.8.0` to `einops==0.8.0`