### PR TITLE
fix version specifier for `einops` in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ gradio
 dill
 accelerate
 timm
-einops=0.8.0
+einops==0.8.0


### PR DESCRIPTION
changed the operator from `=` to `==`