### PR TITLE
updated mirror site for faster GIMP downloading

### DIFF
--- a/omnitool/omnibox/vm/win11setup/setupscripts/tools_config.json
+++ b/omnitool/omnibox/vm/win11setup/setupscripts/tools_config.json
@@ -43,7 +43,7 @@
     },
     "GIMP": {
         "mirrors": [
-            "https://www-ftp.lip6.fr/pub/gimp/gimp/v2.10/windows/gimp-2.10.38-setup.exe",
+            "https://mirrors.aliyun.com/gimp/gimp/v2.10/windows/gimp-2.10.38-setup.exe",
             "https://download.gimp.org/gimp/v2.10/windows/gimp-2.10.38-setup.exe",
             "https://www-ftp.lip6.fr/pub/gimp/gimp/v2.10/windows/gimp-2.10.0-setup.exe"
         ],


### PR DESCRIPTION
In response to Issue #153 

Updated the mirror site for faster downloading GIMP via a new mirror website.