### PR TITLE
Add weights_install.py for Cross-Platform Weight Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,22 @@ conda activate omni
 pip install -r requirements.txt
 ```
 
-Ensure you have the V2 weights downloaded in weights folder (ensure caption weights folder is called icon_caption_florence). If not download them with:
-```
+Ensure you have the V2 weights downloaded in the `weights` folder (ensure the caption weights folder is called `icon_caption_florence`).  
+
+#### **Option 1: Install via Bash (Linux/macOS)**
+```sh
    # download the model checkpoints to local directory OmniParser/weights/
    for f in icon_detect/{train_args.yaml,model.pt,model.yaml} icon_caption/{config.json,generation_config.json,model.safetensors}; do huggingface-cli download microsoft/OmniParser-v2.0 "$f" --local-dir weights; done
    mv weights/icon_caption weights/icon_caption_florence
 ```
+
+#### **Option 2: Install via Python (Windows, macOS, Linux)**
+If you're on Windows or prefer a cross-platform method, use the provided Python script:
+
+```python
+python weights_install.py
+```
+This method ensures compatibility across all operating systems (Windows, macOS, and Linux) without relying on Bash commands.  
 
 <!-- ## [deprecated]
 Then download the model ckpts files in: https://huggingface.co/microsoft/OmniParser, and put them under weights/, default folder structure is: weights/icon_detect, weights/icon_caption_florence, weights/icon_caption_blip2. 

--- a/weights_install.py
+++ b/weights_install.py
@@ -1,0 +1,13 @@
+import os
+import subprocess
+import time
+
+# Define the list of files to download
+files = [
+    "icon_detect/train_args.yaml",
+    "icon_detect/model.pt",
+    "icon_detect/model.yaml",
+    "icon_caption/config.json",
+    "icon_caption/generation_config.json",
+    "icon_caption/model.safetensors"
+]

--- a/weights_install.py
+++ b/weights_install.py
@@ -28,3 +28,9 @@ for file in files:
 # Rename the directory "icon_caption" to "icon_caption_florence"
 icon_caption_path = os.path.join(weights_dir, "icon_caption")
 icon_caption_florence_path = os.path.join(weights_dir, "icon_caption_florence")
+
+if os.path.exists(icon_caption_path):
+    os.rename(icon_caption_path, icon_caption_florence_path)
+    print(f"Renamed {icon_caption_path} to {icon_caption_florence_path}")
+else:
+    print(f"Directory {icon_caption_path} not found!")

--- a/weights_install.py
+++ b/weights_install.py
@@ -11,3 +11,20 @@ files = [
     "icon_caption/generation_config.json",
     "icon_caption/model.safetensors"
 ]
+
+# Define the target directory
+weights_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "weights")
+print(f"Storing weights at: {weights_dir}")
+
+# Ensure the weights directory exists
+os.makedirs(weights_dir, exist_ok=True)
+
+# Loop through each file and download it using Hugging Face CLI
+for file in files:
+    print(f"Downloading {file}...")
+    subprocess.run(["huggingface-cli", "download", "microsoft/OmniParser-v2.0", file, "--local-dir", weights_dir])
+    time.sleep(1)  # Add a short delay to avoid rate-limiting issues
+
+# Rename the directory "icon_caption" to "icon_caption_florence"
+icon_caption_path = os.path.join(weights_dir, "icon_caption")
+icon_caption_florence_path = os.path.join(weights_dir, "icon_caption_florence")


### PR DESCRIPTION
### Add `weights_install.py` for Cross-Platform Weight Installation  

**Description:**  
This PR introduces a new Python script, `weights_install.py`, to simplify downloading model weights using the Hugging Face CLI. The script ensures compatibility across Windows, macOS, and Linux, providing an alternative to the existing Bash-based installation method. Additionally, the README has been updated to reflect this new installation option.  

**Changes:**  
1. **Initialize `weights_install.py`** – Added a Python script to download weights.  
2. **Implement weight download logic** – Uses Hugging Face CLI with automated directory handling.  
3. **Rename `icon_caption` to `icon_caption_florence`** – Ensures consistency with expected folder structure.  
4. **Update README** – Added instructions for using `weights_install.py` as an alternative installation method.  

**Why?**  
- The Bash script is not natively supported on Windows.  
- The Python script provides a universal solution for all operating systems.  

**Testing:**  
- ✅Verified weight downloads successfully on macOS and Linux.  
- ✅Tested on Windows to ensure smooth execution.  

Let me know if any changes are needed! 🚀