### PR TITLE
Add multi-line typing

### DIFF
--- a/omnitool/gradio/agent/vlm_agent.py
+++ b/omnitool/gradio/agent/vlm_agent.py
@@ -144,7 +144,7 @@ class VLMAgent:
             print(f"Total token so far: {self.total_token_usage}. Total cost so far: $USD{self.total_cost:.5f}")
         
         vlm_response_json = extract_data(vlm_response, "json")
-        vlm_response_json = json.loads(vlm_response_json)
+        vlm_response_json = json.loads(vlm_response_json, strict=False)
 
         img_to_show_base64 = parsed_screen["som_image_base64"]
         if "Box ID" in vlm_response_json:

--- a/omnitool/gradio/tools/computer.py
+++ b/omnitool/gradio/tools/computer.py
@@ -171,8 +171,14 @@ class ComputerTool(BaseAnthropicTool):
             
             elif action == "type":
                 # default click before type TODO: check if this is needed
-                self.send_to_vm("pyautogui.click()")
-                self.send_to_vm(f"pyautogui.typewrite('{text}', interval={TYPING_DELAY_MS / 1000})")
+                if "\n" in text:
+                    self.send_to_vm(f"pyperclip.copy(base64.b64decode({base64.b64encode(text.encode('utf8'))}).decode('utf8'))")
+                    self.send_to_vm("pyautogui.keyDown('ctrl')")
+                    self.send_to_vm("pyautogui.press('v')")
+                    self.send_to_vm("pyautogui.keyUp('ctrl')")
+                else:
+                    self.send_to_vm("pyautogui.click()")
+                    self.send_to_vm(f"pyautogui.typewrite('{text}', interval={TYPING_DELAY_MS / 1000})")
                 self.send_to_vm("pyautogui.press('enter')")
                 screenshot_base64 = (await self.screenshot()).base64_image
                 return ToolResult(output=text, base64_image=screenshot_base64)
@@ -228,7 +234,7 @@ class ComputerTool(BaseAnthropicTool):
         """
         Executes a python command on the server. Only return tuple of x,y when action is "pyautogui.position()"
         """
-        prefix = "import pyautogui; pyautogui.FAILSAFE = False;"
+        prefix = "import pyautogui; import pyperclip; import base64; pyautogui.FAILSAFE = False;"
         command_list = ["python", "-c", f"{prefix} {action}"]
         parse = action == "pyautogui.position()"
         if parse:

--- a/omnitool/omnibox/vm/win11setup/setupscripts/server/requirements.txt
+++ b/omnitool/omnibox/vm/win11setup/setupscripts/server/requirements.txt
@@ -1,2 +1,3 @@
 flask
 PyAutoGUI
+pyperclip


### PR DESCRIPTION
Hey there.
So I realized OmniTool had problems with inserting multi-line text, I tried solving it by splitting the multi-line string and typing line separately, but it caused problems with auto-indentation in VSCode. Then I tried using copy and paste and it works pretty well.
Turns out this is also the method UI-TARS uses, even though I didn't knew that at the moment.
I also used base64 to make sure VLM outputs are transferred and pasted exactly.
The code is tested.