### PR TITLE
powershell script to install weights for windows

### DIFF
--- a/install_weights_windows.ps1
+++ b/install_weights_windows.ps1
@@ -1,0 +1,12 @@
+$files = @(
+    "icon_detect/train_args.yaml",
+    "icon_detect/model.pt",
+    "icon_detect/model.yaml",
+    "icon_caption/config.json",
+    "icon_caption/generation_config.json",
+    "icon_caption/model.safetensors"
+)
+
+foreach ($file in $files) {
+    huggingface-cli download microsoft/OmniParser-v2.0 $file --local-dir weights
+}


### PR DESCRIPTION
Current weight folder install instructions only works on unix based machines. Added powershell script perform the same functionality, to build and run the repo on windows based computers.