### PR TITLE
Added clarification on how to download weights if they do not exist l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,16 @@ pip install -r requirements.txt
 ```
 
 Ensure you have the V2 weights downloaded in weights folder (ensure caption weights folder is called icon_caption_florence). If not download them with:
+
+### How to Download Weights if They Do Not Exist Locally
+
+If the model weights are not present in the `weights` directory, you can download them using the following command:
+
+```bash
+huggingface-cli download microsoft/OmniParser-v2.0 --local-dir weights
 ```
-   # download the model checkpoints to local directory OmniParser/weights/
+
+# download the model checkpoints to local directory OmniParser/weights/
    for f in icon_detect/{train_args.yaml,model.pt,model.yaml} icon_caption/{config.json,generation_config.json,model.safetensors}; do huggingface-cli download microsoft/OmniParser-v2.0 "$f" --local-dir weights; done
    mv weights/icon_caption weights/icon_caption_florence
 ```


### PR DESCRIPTION

Updated the README to include clarification on how to download the model weights if they do not exist in the local `weights` directory. Added instructions to run the `huggingface-cli download` command to ensure the necessary weights are downloaded and placed in the correct directory structure.