### PR TITLE
Added maintenance for image cache and handler for HTTPS OmniServer APIs

### DIFF
--- a/omnitool/gradio/loop.py
+++ b/omnitool/gradio/loop.py
@@ -20,6 +20,8 @@ from agent.anthropic_agent import AnthropicActor
 from agent.vlm_agent import VLMAgent
 from agent.vlm_agent_with_orchestrator import VLMOrchestratedAgent
 from executor.anthropic_executor import AnthropicExecutor
+import requests
+from requests.exceptions import RequestException
 
 BETA_FLAG = "computer-use-2024-10-22"
 
@@ -55,7 +57,19 @@ def sampling_loop_sync(
     Synchronous agentic sampling loop for the assistant/tool interaction of computer use.
     """
     print('in sampling_loop_sync, model:', model)
-    omniparser_client = OmniParserClient(url=f"http://{omniparser_url}/parse/")
+    
+    # Try https with a trailing slash if http fails
+    url = omniparser_url
+    try:
+        url_test1 = f'http://{url}/parse'
+        requests.get(url_test1, timeout=3)
+        url = url_test1
+    except RequestException:
+        url_test2 = f'https://{url}/parse/'
+        requests.get(url_test2, timeout=3)
+        url = url_test2
+
+    omniparser_client = OmniParserClient(url=url)
     if model == "claude-3-5-sonnet-20241022":
         # Register Actor and Executor
         actor = AnthropicActor(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ easyocr
 torchvision
 supervision==0.18.0
 openai==1.3.5
-transformers
+transformers==4.45.0
 ultralytics==8.3.70
 azure-identity
 numpy==1.26.4


### PR DESCRIPTION
1. Image Cache
    - Added function to clear screnshot_*.png files from the image cache directory
    - Triggers every time a user clicks the "clear" button on the chatbot history
    
2. HTTPS OmniParser Server Endpoints
    - Relaxed the mandate for running unsecured on HTTP
    - The HTTPS server we tested on required a trailing "/" on /parse/ and /probe/ as well
    - Gradio now attempts both on HTTP first, then tries HTTPS with trailing slash
    
3. Transformers version
    - The latest version of transformers (4.50.0) is not compatible
    - Fixing to 4.45.0 enables running the Omni stack