### PR TITLE
Update Dockerfile

### DIFF
--- a/omnitool/omnibox/Dockerfile
+++ b/omnitool/omnibox/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION_ARG="latest"
 FROM scratch AS build-amd64
 
-COPY --from=qemux/qemu-docker:6.08 / /
+COPY --from=qemux/qemu:6.18 / /
 
 ARG DEBCONF_NOWARNINGS="yes"
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Changed docker image to qemu with version 6.18 from qemu-docker. The docker image qemu-docker is not longer exist on the qemux docker hub.