### PR TITLE
Fixed transformers library version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ easyocr
 torchvision
 supervision==0.18.0
 openai==1.3.5
-transformers
+transformers==4.39.3
 ultralytics==8.3.70
 azure-identity
 numpy==1.26.4


### PR DESCRIPTION
Fixed version of 🤗 transformers to 4.39.3, as the latest version will result in an error `AttributeError: 'Florence2ForConditionalGeneration' object has no attribute '_supports_sdpa'`