### PR TITLE
Add lightweight FastAPI server for OmniParser + minor utils refactor & README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,71 @@ To run gradio demo, simply run:
 python gradio_demo.py
 ```
 
+## 🚀 Features
+
+### FastAPI Integration
+A REST API using **FastAPI** is developed to process images uploaded by users, analyze them using **OmniParser**, and return both:
+- The **structured results** (JSON list of detections), and  
+- A **labeled image** with bounding boxes.
+
+This enables remote interaction with OmniParser as a standalone service.
+
+---
+
+## ⚙️ Start the Server
+
+Launch the FastAPI server by running `app.py`.
+Once running, the API will listen on port 5000 by default.
+
+Send a POST request to:
+```
+http://<your-server-address>:5000/process
+```
+The API returns a structured list of detections, each represented as:
+```
+["ID", "Type", "Text", "x1", "y1", "x2", "y2"]
+```
+🧪 Example: Send an Image via Python
+```python
+import requests
+import base64
+from PIL import Image
+from io import BytesIO
+from os.path import basename
+
+# API endpoint
+url = "http://<your-server-address>:5000/process"
+
+# Path to the image you want to send
+image_path = "path/to/your/image.png"
+image_name = basename(image_path)
+
+# Send the image as a POST request
+with open(image_path, 'rb') as image_file:
+    response = requests.post(
+        url,
+        files={'image': image_file},
+        data={'img_name': image_name}
+    )
+
+# Check the response
+if response.status_code == 200:
+    data = response.json()
+
+    # Get the base64 image from the response
+    base64_image = data['base64_image']
+
+    # Decode and open the labeled image
+    image_data = base64.b64decode(base64_image)
+    image = Image.open(BytesIO(image_data))
+    image.show()
+
+    print("Structured results:", data["structured_results"])
+else:
+    print(f"Failed to get a response. Status code: {response.status_code}")
+
+```
+
 ## Model Weights License
 For the model checkpoints on huggingface model hub, please note that icon_detect model is under AGPL license since it is a license inherited from the original yolo model. And icon_caption_blip2 & icon_caption_florence is under MIT license. Please refer to the LICENSE file in the folder of each model: https://huggingface.co/microsoft/OmniParser.
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,122 @@
+import io
+import os
+import numpy as np
+import time
+import torch
+import logging
+from fastapi import FastAPI, File, UploadFile, Form, HTTPException
+from fastapi.responses import JSONResponse
+from PIL import Image
+from util.utils import check_ocr_box, get_yolo_model, get_caption_model_processor, get_som_labeled_img, \
+    prepare_structured_results, convert_ocr_results_to_json
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Initialize FastAPI app
+app = FastAPI()
+
+# Load models and processors with error handling
+try:
+    yolo_model = get_yolo_model(model_path=os.getenv('YOLO_MODEL_PATH', 'weights/icon_detect/model.pt'))
+    caption_model_processor = get_caption_model_processor(
+        model_name="florence2", 
+        model_name_or_path=os.getenv('CAPTION_MODEL_PATH', 'weights/icon_caption_florence')
+    )
+except Exception as e:
+    logger.error(f"Error loading models: {e}")
+    raise
+
+DEVICE = torch.device(os.getenv('DEVICE', 'cuda'))
+
+# Define the processing function
+def process_image(
+    image_input: Image.Image,
+    image_name: str,
+    box_threshold: float = 0.05,
+    iou_threshold: float = 0.1,
+    use_paddleocr: bool = True,
+    imgsz: int = 640) -> tuple:
+    start_time = time.time()
+
+    try:
+        # Save the input image
+        image_save_path = 'imgs/saved_image_input.png'
+        image_input.save(image_save_path)
+        with Image.open(image_save_path) as image:
+            box_overlay_ratio = image.size[0] / 3200
+            draw_bbox_config = {
+                'text_scale': 0.8 * box_overlay_ratio,
+                'text_thickness': max(int(2 * box_overlay_ratio), 1),
+                'text_padding': max(int(3 * box_overlay_ratio), 1),
+                'thickness': max(int(3 * box_overlay_ratio), 1),
+            }
+
+            # ocr_bbox_rslt, is_goal_filtered = check_ocr_box(
+            #     image_save_path, display_img=False, output_bb_format='xyxy',
+            #     goal_filtering=None, easyocr_args={'paragraph': False, 'text_threshold': 0.9},
+            #     use_paddleocr=use_paddleocr
+            # )
+            ocr_bbox_rslt, is_goal_filtered = check_ocr_box(image_save_path, display_img = False, output_bb_format='xyxy', goal_filtering=None, easyocr_args={'paragraph': False, 'text_threshold':0.8}, use_paddleocr=False)
+
+            text, ocr_bbox = ocr_bbox_rslt
+            print(text, ocr_bbox, 'text, ocr_bbox')
+            # Convert OCR results to JSON format
+            ocr_json = convert_ocr_results_to_json(image_name, text, ocr_bbox)
+
+            # dino_labled_img, label_coordinates, parsed_content_list = get_som_labeled_img(
+            #     image_save_path, yolo_model, BOX_TRESHOLD=box_threshold,
+            #     output_coord_in_ratio=True, ocr_bbox=ocr_bbox, draw_bbox_config=draw_bbox_config,
+            #     caption_model_processor=caption_model_processor, ocr_text=text,
+            #     iou_threshold=iou_threshold, imgsz=imgsz
+            # )
+            dino_labled_img, label_coordinates, parsed_content_list = get_som_labeled_img(image_save_path, yolo_model, BOX_TRESHOLD = box_threshold, output_coord_in_ratio=True, ocr_bbox=ocr_bbox,draw_bbox_config=draw_bbox_config, caption_model_processor=caption_model_processor, ocr_text=text,use_local_semantics=True, iou_threshold=0.7, scale_img=False, batch_size=128)
+
+
+            # Use the new function
+            structured_results = prepare_structured_results(parsed_content_list, label_coordinates, image_input)
+
+    except Exception as e:
+        logger.error(f"Error processing image: {e}")
+        raise HTTPException(status_code=500, detail="Internal Server Error")
+
+    end_time = time.time()
+    processing_time = end_time - start_time
+
+    return label_coordinates, parsed_content_list, processing_time, ocr_bbox_rslt, structured_results, ocr_json, dino_labled_img
+
+@app.post("/process")
+async def process_route(image: UploadFile = File(...), img_name: str = Form(...)):
+    try:
+        image_data = await image.read()
+        image_input = Image.open(io.BytesIO(image_data))
+    except Exception as e:
+        logger.error(f"Error reading image: {e}")
+        raise HTTPException(status_code=400, detail="Invalid image file")
+
+    # Process the image
+    label_coords, content_list, processing_time, ocr_bbox_rslt, structured_results, ocr_json, dino_labeled_img = process_image(
+        image_input=image_input,
+        image_name=img_name,
+        box_threshold=0.05,
+        iou_threshold=0.1,
+        use_paddleocr=True,
+        imgsz=640,
+    )
+
+    # Convert any ndarray objects to lists
+    label_coords = {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in label_coords.items()}
+
+    print(structured_results, 'structured_results')
+
+    # Return the results as JSON
+    return JSONResponse(content={
+        "based64_image": dino_labeled_img,
+        "ocr_json": ocr_json,
+        "structured_results": structured_results
+    })
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=int(os.getenv('PORT', 5003)))

--- a/util/utils.py
+++ b/util/utils.py
@@ -396,6 +396,22 @@ def predict_yolo(model, image, box_threshold, imgsz, scale_img, iou_threshold=0.
     conf = result[0].boxes.conf
     phrases = [str(i) for i in range(len(boxes))]
 
+    # Convert image to numpy array if it's not already
+    if isinstance(image, str):
+        image = cv2.imread(image)
+    elif isinstance(image, Image.Image):
+        image = np.array(image)
+
+    # Draw bounding boxes on the image
+    for box in boxes:
+        x1, y1, x2, y2 = map(int, box)
+        cv2.rectangle(image, (x1, y1), (x2, y2), (0, 255, 0), 2)  # Green box with thickness 2
+
+    # Display the image with bounding boxes
+    plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+    plt.axis('off')
+    plt.show()
+
     return boxes, conf, phrases
 
 def int_box_area(box, w, h):
@@ -538,3 +554,45 @@ def check_ocr_box(image_source: Union[str, Image.Image], display_img = True, out
         elif output_bb_format == 'xyxy':
             bb = [get_xyxy(item) for item in coord]
     return (text, bb), goal_filtering
+
+def prepare_structured_results(parsed_content_list, label_coordinates, image_input):
+    """     
+    The output will be a list of lists of strings (List[List[str]]). Each list of strings (List[str]) represents one detection 
+    in the format: ["ID", "Type", "Text", "Interactivity", "x1", "y1", "w", "h"].
+    - "ID" is the identifier of the detected box.
+    - "Type" is the type of the detected box, either "Text" or "icon".
+    - "Text" is the label or content associated with the detected box.
+    - "x1", "y1" are the coordinates of the top-left corner of the detected box.
+    - "w", "h" are the width and height of the detected box.
+    """
+    structured_results = []
+    img_width, img_height = image_input.size
+
+    for idx, entry in enumerate(parsed_content_list):
+        box_type = "text" if entry['type'] == 'text' else "icon"
+        label = entry['content']
+        box_id = str(idx)
+        if label=="Close (Ctrl+F4)" or "Microsoft Excel" in label:
+            label = "Close"
+
+        if  box_id in label_coordinates:# and entry['interactivity']:
+            coords = label_coordinates[box_id]
+            x1 = int(coords[0] * img_width)
+            y1 = int(coords[1] * img_height)
+            w = int(coords[2] * img_width)
+            h = int(coords[3] * img_height)
+            interactive = entry['interactivity']
+            structured_results.append([box_id, box_type, label, interactive, str(x1), str(y1), str(w), str(h)])
+    
+    return structured_results
+
+def convert_ocr_results_to_json(image_name, text, ocr_bbox, file_path="ocr_results.json"):
+    """
+    Convert OCR results to JSON format and save to a file.
+    """
+    ocr_json = {
+        image_name: [
+            [t, str(b[0]), str(b[1]), str(b[2]), str(b[3])] for t, b in zip(text, ocr_bbox)
+        ]
+    }
+    return ocr_json


### PR DESCRIPTION
This PR adds a minimal FastAPI server so OmniParser can be used via an HTTP endpoint, enabling easy integration from other projects without importing the library directly. It also includes a small utils refactor and updates the README with quick-start API examples.
