### PR TITLE
Fix PaddleOCR 2.9+ args, Box Sorting, and pin Transformers (Florence-2 fix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ easyocr
 torchvision
 supervision==0.18.0
 openai==1.3.5
-transformers
+transformers==4.40.0
 ultralytics==8.3.70
 azure-identity
 numpy==1.26.4
@@ -29,4 +29,5 @@ google-auth<3,>=2
 screeninfo
 uiautomation
 dashscope
+
 groq

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,18 +3,32 @@ easyocr
 torchvision
 supervision==0.18.0
 openai==1.3.5
+
+# Fix for Florence2 Crash
 transformers==4.40.0
+
 ultralytics==8.3.70
 azure-identity
 numpy==1.26.4
-opencv-python
+
+# If you need an interactive, desktop-level GUI features, use 'opencv-python' and comment out opencv-python-headless, both of them contain the same core file.
+
+# Includes GUI dependencies (like Qt)
+#opencv-python
+
+# Removes the GUI dependencies. This is smaller and designed for server environments.
 opencv-python-headless
+
 gradio
 dill
 accelerate
 timm
 einops==0.8.0
+
+# To use the model on a GPU, change paddlepaddle to: paddlepaddle-gpu
 paddlepaddle
+# paddleocr won't be able to find the GPU since paddlepaddle is a CPU-only library.
+
 paddleocr
 ruff==0.6.7
 pre-commit==3.8.0
@@ -31,3 +45,4 @@ uiautomation
 dashscope
 
 groq
+

--- a/util/utils.py
+++ b/util/utils.py
@@ -22,13 +22,7 @@ from paddleocr import PaddleOCR
 reader = easyocr.Reader(['en'])
 paddle_ocr = PaddleOCR(
     lang='en',  # other lang also available
-    use_angle_cls=False,
-    use_gpu=False,  # using cuda will conflict with pytorch in the same process
-    show_log=False,
-    max_batch_size=1024,
-    use_dilation=True,  # improves accuracy
-    det_db_score_mode='slow',  # improves accuracy
-    rec_batch_num=1024)
+)
 import time
 import base64
 
@@ -41,7 +35,7 @@ import re
 from torchvision.transforms import ToPILImage
 import supervision as sv
 import torchvision.transforms as T
-from util.box_annotator import BoxAnnotator 
+from .box_annotator import BoxAnnotator 
 
 
 def get_caption_model_processor(model_name, model_name_or_path="Salesforce/blip2-opt-2.7b", device=None):
@@ -430,13 +424,24 @@ def get_som_labeled_img(image_source: Union[str, Image.Image], model=None, BOX_T
     else:
         print('no ocr bbox!!!')
         ocr_bbox = None
-
+    if ocr_bbox is None: ocr_bbox = []
+    if ocr_text is None: ocr_text = []
     ocr_bbox_elem = [{'type': 'text', 'bbox':box, 'interactivity':False, 'content':txt, 'source': 'box_ocr_content_ocr'} for box, txt in zip(ocr_bbox, ocr_text) if int_box_area(box, w, h) > 0] 
     xyxy_elem = [{'type': 'icon', 'bbox':box, 'interactivity':True, 'content':None} for box in xyxy.tolist() if int_box_area(box, w, h) > 0]
     filtered_boxes = remove_overlap_new(boxes=xyxy_elem, iou_threshold=iou_threshold, ocr_bbox=ocr_bbox_elem)
     
     # sort the filtered_boxes so that the one with 'content': None is at the end, and get the index of the first 'content': None
-    filtered_boxes_elem = sorted(filtered_boxes, key=lambda x: x['content'] is None)
+    # filtered_boxes_elem = sorted(filtered_boxes, key=lambda x: x['content'] is None)
+    safe_boxes = []
+    for item in filtered_boxes:
+        # If the item is just a list of coordinates (the bug), wrap it in a dict
+        if isinstance(item, (list, tuple)):
+            safe_boxes.append({'type': 'icon', 'bbox': item, 'content': None})
+        else:
+            safe_boxes.append(item)
+    
+    # Now sort the safe list
+    filtered_boxes_elem = sorted(safe_boxes, key=lambda x: x.get('content') is None)
     # get the index of the first 'content': None
     starting_idx = next((i for i, box in enumerate(filtered_boxes_elem) if box['content'] is None), -1)
     filtered_boxes = torch.tensor([box['bbox'] for box in filtered_boxes_elem])
@@ -474,17 +479,13 @@ def get_som_labeled_img(image_source: Union[str, Image.Image], model=None, BOX_T
         annotated_frame, label_coordinates = annotate(image_source=image_source, boxes=filtered_boxes, logits=logits, phrases=phrases, **draw_bbox_config)
     else:
         annotated_frame, label_coordinates = annotate(image_source=image_source, boxes=filtered_boxes, logits=logits, phrases=phrases, text_scale=text_scale, text_padding=text_padding)
-    
+        
     pil_img = Image.fromarray(annotated_frame)
-    buffered = io.BytesIO()
-    pil_img.save(buffered, format="PNG")
-    encoded_image = base64.b64encode(buffered.getvalue()).decode('ascii')
     if output_coord_in_ratio:
         label_coordinates = {k: [v[0]/w, v[1]/h, v[2]/w, v[3]/h] for k, v in label_coordinates.items()}
         assert w == annotated_frame.shape[1] and h == annotated_frame.shape[0]
-
-    return encoded_image, label_coordinates, filtered_boxes_elem
-
+        
+    return pil_img, label_coordinates, filtered_boxes_elem
 
 def get_xywh(input):
     x, y, w, h = input[0][0], input[0][1], input[2][0] - input[0][0], input[2][1] - input[0][1]

--- a/util/utils.py
+++ b/util/utils.py
@@ -494,12 +494,16 @@ def get_som_labeled_img(image_source: Union[str, Image.Image], model=None, BOX_T
         annotated_frame, label_coordinates = annotate(image_source=image_source, boxes=filtered_boxes, logits=logits, phrases=phrases, text_scale=text_scale, text_padding=text_padding)
         
     pil_img = Image.fromarray(annotated_frame)
+    
+    buffered = io.BytesIO()
+    pil_img.save(buffered, format="PNG")
+    encoded_image = base64.b64encode(buffered.getvalue()).decode('ascii')
+    
     if output_coord_in_ratio:
         label_coordinates = {k: [v[0]/w, v[1]/h, v[2]/w, v[3]/h] for k, v in label_coordinates.items()}
         assert w == annotated_frame.shape[1] and h == annotated_frame.shape[0]
         
-    return pil_img, label_coordinates, filtered_boxes_elem
-
+    return encoded_image, label_coordinates, filtered_boxes_elem
 def get_xywh(input):
     x, y, w, h = input[0][0], input[0][1], input[2][0] - input[0][0], input[2][1] - input[0][1]
     x, y, w, h = int(x), int(y), int(w), int(h)

--- a/util/utils.py
+++ b/util/utils.py
@@ -446,14 +446,17 @@ def get_som_labeled_img(image_source: Union[str, Image.Image], model=None, BOX_T
     for item in filtered_boxes:
         # If the item is just a list of coordinates (the bug), wrap it in a dict
         if isinstance(item, (list, tuple)):
-            safe_boxes.append({'type': 'icon', 'bbox': item, 'content': None})
+            safe_boxes.append({'type': 'icon', 'bbox': list(item), 'interactivity': True, 'content': None, 'source': 'box_yolo_content_yolo'})
         else:
+            # Ensure required keys exist so downstream code can safely index
+            if isinstance(item, dict):
+                item.setdefault('content', None)
             safe_boxes.append(item)
-    
+
     # Now sort the safe list
     filtered_boxes_elem = sorted(safe_boxes, key=lambda x: x.get('content') is None)
     # get the index of the first 'content': None
-    starting_idx = next((i for i, box in enumerate(filtered_boxes_elem) if box['content'] is None), -1)
+    starting_idx = next((i for i, box in enumerate(filtered_boxes_elem) if box.get('content') is None), len(filtered_boxes_elem))
     filtered_boxes = torch.tensor([box['bbox'] for box in filtered_boxes_elem])
     print('len(filtered_boxes):', len(filtered_boxes), starting_idx)
 


### PR DESCRIPTION
Summary of Changes

This PR addresses two compatibility issues encountered when setting up the environment with recent library versions (specifically PaddleOCR v2.9.1).

1. Fix PaddleOCR Initialization
Newer versions of `paddleocr` have deprecated/removed arguments like `max_batch_size`, `use_gpu`, and `use_dilation` from the constructor. Keeping them causes a `ValueError` crash on startup. 
Change: Updated `PaddleOCR()` initialization to rely on default argument parsing, which correctly auto-detects GPU support.

2. Box Sorting
Occasionally, `filtered_boxes` contains mixed types (dictionaries and raw lists) depending on the detection results. This causes the `sorted()` function (line ~435) to crash with an `AttributeError` because raw lists do not have keys.
Change: Added a safety check loop (`safe_boxes`) to ensure all elements in `filtered_boxes` are standardized dictionaries before sorting.

3. Fix Florence-2 Inference Crash
 The current dependency resolution installs a version of transformers (v4.41+) that is incompatible with the custom modeling_florence2.py, causing an AttributeError: 'NoneType' object has no attribute 'shape'. Change: Pinned transformers==4.40.0 in requirements.txt to ensure stability.

Testing
- Verified environment setup on Windows with Python 3.10 and PaddleOCR 2.9.1.
- Validated that the model loads and performs inference without crashing.