### PR TITLE
fix: guard against empty/filtered LLM responses in groqclient

### DIFF
--- a/omnitool/gradio/agent/llm_utils/groqclient.py
+++ b/omnitool/gradio/agent/llm_utils/groqclient.py
@@ -47,6 +47,8 @@ def run_groq_interleaved(messages: list, system: str, model_name: str, api_key: 
             reasoning_format="raw"
         )
         
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         response = completion.choices[0].message.content
         final_answer = response.split('</think>\n')[-1] if '</think>' in response else response
         final_answer = final_answer.replace("<output>", "").replace("</output>", "")


### PR DESCRIPTION
## What

Adds a null check in `omnitool/gradio/agent/llm_utils/groqclient.py` before accessing `completion.choices[0].message`.

## Why

Two silent failure modes crash at this line:

1. **`IndexError`** — `choices` is an empty list when the provider returns no completions
2. **`AttributeError`** — `choices[0].message` is `None` when content is filtered (some providers return HTTP 200 with a filtered finish reason)

## Fix

```python
if not completion.choices or completion.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
response = completion.choices[0].message.content
```

Detected by [pact](https://github.com/qizwiz/pact) static analysis.