### PR TITLE
Add Hugging Face-backed YOLOv9-E detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ weights/icon_caption_florence
 weights/icon_detect/
 weights/icon_detect_v1_5/
 weights/icon_detect_v1_5_2/
+weights/icon_detect_v3/
 .gradio
 __pycache__/
 debug.ipynb

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 **OmniParser** is a comprehensive method for parsing user interface screenshots into structured and easy-to-understand elements, which significantly enhances the ability of GPT-4V to generate actions that can be accurately grounded in the corresponding regions of the interface. 
 
 ## News
+- [2026/7] We add a YOLOv9-E interactive region detector. Its inference-only weight is available in [Hugging Face PR #37](https://huggingface.co/microsoft/OmniParser-v2.0/discussions/37).
 - [2025/3] We support local logging of trajecotry so that you can use OmniParser+OmniTool to build training data pipeline for your favorate agent in your domain. [Documentation WIP]
 - [2025/3] We are gradually adding multi agents orchstration and improving user interface in OmniTool for better experience.
 - [2025/2] We release OmniParser V2 [checkpoints](https://huggingface.co/microsoft/OmniParser-v2.0). [Watch Video](https://1drv.ms/v/c/650b027c18d5a573/EWXbVESKWo9Buu6OYCwg06wBeoM97C6EOTG6RjvWLEN1Qg?e=alnHGC)
@@ -33,10 +34,15 @@ conda activate omni
 pip install -r requirements.txt
 ```
 
-Ensure you have the V2 weights downloaded in weights folder (ensure caption weights folder is called icon_caption_florence). If not download them with:
+Until [Hugging Face PR #37](https://huggingface.co/microsoft/OmniParser-v2.0/discussions/37) is merged, download the latest YOLOv9-E detector from the PR:
 ```
-   # download the model checkpoints to local directory OmniParser/weights/
-   for f in icon_detect/{train_args.yaml,model.pt,model.yaml} icon_caption/{config.json,generation_config.json,model.safetensors}; do huggingface-cli download microsoft/OmniParser-v2.0 "$f" --local-dir weights; done
+huggingface-cli download microsoft/OmniParser-v2.0 icon_detect_v3/model.pt \
+  --revision refs/pr/37 --local-dir weights
+```
+
+OmniParser prefers this local weight. After the PR is merged, it will download the same weight automatically on first use. Download the caption weights into the `weights` folder:
+```
+   for f in icon_caption/{config.json,generation_config.json,model.safetensors}; do huggingface-cli download microsoft/OmniParser-v2.0 "$f" --local-dir weights; done
    mv weights/icon_caption weights/icon_caption_florence
 ```
 
@@ -62,7 +68,7 @@ python gradio_demo.py
 ```
 
 ## Model Weights License
-For the model checkpoints on huggingface model hub, please note that icon_detect model is under AGPL license since it is a license inherited from the original yolo model. And icon_caption_blip2 & icon_caption_florence is under MIT license. Please refer to the LICENSE file in the folder of each model: https://huggingface.co/microsoft/OmniParser.
+`icon_detect_v3` is based on the MIT-licensed YOLOv9 implementation. Earlier Ultralytics-based icon detectors retain their original AGPL license. The caption models are under the MIT license.
 
 ## 📚 Citation
 Our technical report can be found [here](https://arxiv.org/abs/2408.00203).

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -16,14 +16,11 @@
    "source": [
     "from util.utils import get_som_labeled_img, check_ocr_box, get_caption_model_processor, get_yolo_model\n",
     "import torch\n",
-    "from ultralytics import YOLO\n",
     "from PIL import Image\n",
     "device = 'cuda'\n",
-    "model_path='weights/icon_detect/model.pt'\n",
     "\n",
-    "som_model = get_yolo_model(model_path)\n",
+    "som_model = get_yolo_model(device=device)\n",
     "\n",
-    "som_model.to(device)\n",
     "print('model to {}'.format(device))"
    ]
   },

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -12,7 +12,7 @@ from util.utils import check_ocr_box, get_yolo_model, get_caption_model_processo
 import torch
 from PIL import Image
 
-yolo_model = get_yolo_model(model_path='weights/icon_detect/model.pt')
+yolo_model = get_yolo_model()
 caption_model_processor = get_caption_model_processor(model_name="florence2", model_name_or_path="weights/icon_caption_florence")
 # caption_model_processor = get_caption_model_processor(model_name="blip2", model_name_or_path="weights/icon_caption_blip2")
 

--- a/omnitool/omniparserserver/omniparserserver.py
+++ b/omnitool/omniparserserver/omniparserserver.py
@@ -1,5 +1,5 @@
 '''
-python -m omniparserserver --som_model_path ../../weights/icon_detect/model.pt --caption_model_name florence2 --caption_model_path ../../weights/icon_caption_florence --device cuda --BOX_TRESHOLD 0.05
+python -m omniparserserver --caption_model_name florence2 --caption_model_path ../../weights/icon_caption_florence --device cuda --BOX_TRESHOLD 0.05
 '''
 
 import sys
@@ -15,7 +15,7 @@ from util.omniparser import Omniparser
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Omniparser API')
-    parser.add_argument('--som_model_path', type=str, default='../../weights/icon_detect/model.pt', help='Path to the som model')
+    parser.add_argument('--som_model_path', type=str, default=None, help='Optional local detector path; V3 downloads from Hugging Face by default')
     parser.add_argument('--caption_model_name', type=str, default='florence2', help='Name of the caption model')
     parser.add_argument('--caption_model_path', type=str, default='../../weights/icon_caption_florence', help='Path to the caption model')
     parser.add_argument('--device', type=str, default='cpu', help='Device to run the model')

--- a/omnitool/readme.md
+++ b/omnitool/readme.md
@@ -62,10 +62,11 @@ There are three components:
 
    g. Continue from here if you already had the conda environment.
 
-   h. Ensure you have the V2 weights downloaded in weights folder (**ensure caption weights folder is called icon_caption_florence**). If not download them with:
+   h. Until Hugging Face PR 37 is merged, download the latest detector from the PR. Then download the caption weights:
    ```
-   rm -rf weights/icon_detect weights/icon_caption weights/icon_caption_florence 
-   for folder in icon_caption icon_detect; do huggingface-cli download microsoft/OmniParser-v2.0 --local-dir weights --repo-type model --include "$folder/*"; done
+   huggingface-cli download microsoft/OmniParser-v2.0 icon_detect_v3/model.pt --revision refs/pr/37 --local-dir weights
+   rm -rf weights/icon_caption weights/icon_caption_florence
+   huggingface-cli download microsoft/OmniParser-v2.0 --local-dir weights --repo-type model --include "icon_caption/*"
    mv weights/icon_caption weights/icon_caption_florence
    ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ torchvision
 supervision==0.18.0
 openai==1.3.5
 transformers
+huggingface_hub
 ultralytics==8.3.70
 azure-identity
 numpy==1.26.4

--- a/util/omniparser.py
+++ b/util/omniparser.py
@@ -9,7 +9,7 @@ class Omniparser(object):
         self.config = config
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
-        self.som_model = get_yolo_model(model_path=config['som_model_path'])
+        self.som_model = get_yolo_model(model_path=config.get('som_model_path'), device=device)
         self.caption_model_processor = get_caption_model_processor(model_name=config['caption_model_name'], model_name_or_path=config['caption_model_path'], device=device)
         print('Omniparser initialized!!!')
 

--- a/util/utils.py
+++ b/util/utils.py
@@ -35,6 +35,7 @@ import base64
 import os
 import ast
 import torch
+from pathlib import Path
 from typing import Tuple, List, Union
 from torchvision.ops import box_convert
 import re
@@ -68,11 +69,20 @@ def get_caption_model_processor(model_name, model_name_or_path="Salesforce/blip2
     return {'model': model.to(device), 'processor': processor}
 
 
-def get_yolo_model(model_path):
+def get_yolo_model(model_path=None, device=None):
+    if model_path is None:
+        local_model_path = Path(__file__).resolve().parents[1] / "weights/icon_detect_v3/model.pt"
+        if local_model_path.is_file():
+            model_path = local_model_path
+
+    if model_path is None or "icon_detect_v3" in Path(model_path).parts:
+        from util.yolov9 import YOLOv9Detector
+
+        return YOLOv9Detector(model_path=model_path, device=device)
+
     from ultralytics import YOLO
-    # Load the model.
-    model = YOLO(model_path)
-    return model
+
+    return YOLO(model_path)
 
 
 @torch.inference_mode()

--- a/util/yolov9.py
+++ b/util/yolov9.py
@@ -1,0 +1,136 @@
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from PIL import Image
+from torchvision.ops import batched_nms
+
+
+DEFAULT_REPO_ID = "microsoft/OmniParser-v2.0"
+DEFAULT_MODEL_FILE = "icon_detect_v3/model.pt"
+
+
+class Boxes:
+    def __init__(self, xyxy: torch.Tensor, confidence: torch.Tensor):
+        self.xyxy = xyxy
+        self.conf = confidence
+
+
+class Result:
+    def __init__(self, boxes: Boxes):
+        self.boxes = boxes
+
+
+class YOLOv9Detector:
+    """TorchScript YOLOv9-E detector with an Ultralytics-compatible predict API."""
+
+    strides = (8, 16, 32)
+
+    def __init__(
+        self,
+        model_path: Union[str, Path, None] = None,
+        device: Union[str, torch.device, None] = None,
+        repo_id: str = DEFAULT_REPO_ID,
+        revision: str = "main",
+    ):
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        if self.device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError(f"CUDA device requested but unavailable: {self.device}")
+
+        if model_path is None:
+            model_path = hf_hub_download(
+                repo_id=repo_id,
+                filename=DEFAULT_MODEL_FILE,
+                revision=revision,
+            )
+        self.model_path = Path(model_path)
+        self.model = torch.jit.load(str(self.model_path), map_location=self.device).eval()
+
+    @staticmethod
+    def _normalize_image_size(image_size):
+        if isinstance(image_size, int):
+            width = height = image_size
+        elif len(image_size) == 2:
+            height, width = image_size
+        else:
+            raise ValueError(f"Expected one or two image dimensions, got {image_size}")
+        width = ((int(width) + 31) // 32) * 32
+        height = ((int(height) + 31) // 32) * 32
+        return width, height
+
+    @staticmethod
+    def _load_image(source):
+        if isinstance(source, Image.Image):
+            return source.convert("RGB")
+        if isinstance(source, np.ndarray):
+            return Image.fromarray(source).convert("RGB")
+        with Image.open(source) as image:
+            return image.convert("RGB")
+
+    def _preprocess(self, image, image_size):
+        target_width, target_height = self._normalize_image_size(image_size)
+        image_width, image_height = image.size
+        scale = min(target_width / image_width, target_height / image_height)
+        resized_width = int(image_width * scale)
+        resized_height = int(image_height * scale)
+        pad_left = (target_width - resized_width) // 2
+        pad_top = (target_height - resized_height) // 2
+
+        resized = image.resize((resized_width, resized_height), Image.Resampling.LANCZOS)
+        padded = Image.new("RGB", (target_width, target_height), (114, 114, 114))
+        padded.paste(resized, (pad_left, pad_top))
+        image_array = np.asarray(padded, dtype=np.float32).transpose(2, 0, 1) / 255.0
+        image_tensor = torch.from_numpy(image_array).unsqueeze(0).to(self.device)
+        return image_tensor, scale, pad_left, pad_top
+
+    def _decode(self, outputs):
+        class_logits = []
+        decoded_boxes = []
+        for output_index, stride in zip(range(0, len(outputs), 2), self.strides):
+            layer_logits, layer_distances = outputs[output_index : output_index + 2]
+            batch_size, _, height, width = layer_logits.shape
+            layer_logits = layer_logits.permute(0, 2, 3, 1).reshape(batch_size, -1, layer_logits.shape[1])
+            layer_distances = layer_distances.permute(0, 2, 3, 1).reshape(batch_size, -1, 4) * stride
+
+            grid_y, grid_x = torch.meshgrid(
+                torch.arange(height, device=self.device),
+                torch.arange(width, device=self.device),
+                indexing="ij",
+            )
+            anchors = (torch.stack((grid_x, grid_y), dim=-1).reshape(-1, 2) + 0.5) * stride
+            left_top, right_bottom = layer_distances.chunk(2, dim=-1)
+            decoded_boxes.append(torch.cat((anchors - left_top, anchors + right_bottom), dim=-1))
+            class_logits.append(layer_logits)
+
+        return torch.cat(class_logits, dim=1).sigmoid(), torch.cat(decoded_boxes, dim=1)
+
+    def _inference_context(self):
+        if self.device.type == "cuda":
+            return torch.autocast(device_type="cuda", dtype=torch.float16)
+        return nullcontext()
+
+    @torch.inference_mode()
+    def predict(self, source, conf=0.25, imgsz=640, iou=0.7, max_det=300):
+        image = self._load_image(source)
+        image_tensor, scale, pad_left, pad_top = self._preprocess(image, imgsz)
+
+        with self._inference_context(), torch.jit.optimized_execution(False):
+            class_scores, boxes = self._decode(self.model(image_tensor))
+
+        scores, class_ids = class_scores[0].max(dim=-1)
+        valid = scores > conf
+        scores = scores[valid]
+        class_ids = class_ids[valid]
+        boxes = boxes[0][valid]
+        boxes[:, [0, 2]] = (boxes[:, [0, 2]] - pad_left) / scale
+        boxes[:, [1, 3]] = (boxes[:, [1, 3]] - pad_top) / scale
+
+        keep = batched_nms(boxes, scores, class_ids, iou)[:max_det]
+        boxes = boxes[keep]
+        scores = scores[keep]
+        boxes[:, [0, 2]] = boxes[:, [0, 2]].clamp(0, image.width)
+        boxes[:, [1, 3]] = boxes[:, [1, 3]].clamp(0, image.height)
+        return [Result(Boxes(boxes, scores))]


### PR DESCRIPTION
## Summary
- add a native PyTorch/TorchScript YOLOv9-E detector adapter
- prefer the ignored local V3 weight and otherwise download from Hugging Face
- preserve legacy Ultralytics model paths and update demos, server defaults, and docs

## Model weight
- Hugging Face PR: https://huggingface.co/microsoft/OmniParser-v2.0/discussions/37
- contains only `icon_detect_v3/model.pt` (no optimizer or separate EMA state)

## Validation
- downloaded the PR artifact into a fresh cache
- evaluated the same 10 validation images: 192 TP, 88 FP, 93 FN, 67.96% F1
- verified GPU and CPU inference